### PR TITLE
Implement basic UCI engine skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.10)
+project(ct2 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Add source files
+add_library(ct2lib
+    src/board.cpp
+    src/uci.cpp
+)
+
+target_include_directories(ct2lib PUBLIC src)
+
+add_executable(ct2 src/main.cpp)
+target_link_libraries(ct2 PRIVATE ct2lib)
+
+# tests
+enable_testing()
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(ct2_tests tests/board_tests.cpp)
+target_link_libraries(ct2_tests PRIVATE ct2lib gtest_main)
+
+add_test(NAME ct2_tests COMMAND ct2_tests)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # ct2
+
+This project contains a minimal C++ chess engine skeleton. It provides:
+
+- A basic board representation using bitboards
+- Magic bitboard attack tables for sliding pieces
+- A simple UCI interface
+- Unit tests using GoogleTest
+
+## Building
+
+```
+cmake -S . -B build
+cmake --build build
+```
+
+## Running
+
+To start the engine:
+
+```
+./build/ct2
+```
+
+## Testing
+
+```
+cmake --build build --target ct2_tests
+./build/ct2_tests
+```

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1,0 +1,229 @@
+#include "board.h"
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+namespace ct2 {
+
+namespace {
+
+inline int char_to_piece(char c) {
+    switch (c) {
+    case 'P': return WP;
+    case 'N': return WN;
+    case 'B': return WB;
+    case 'R': return WR;
+    case 'Q': return WQ;
+    case 'K': return WK;
+    case 'p': return BP;
+    case 'n': return BN;
+    case 'b': return BB;
+    case 'r': return BR;
+    case 'q': return BQ;
+    case 'k': return BK;
+    default: return -1;
+    }
+}
+
+} // namespace
+
+Board::Board() {
+    bitboards.fill(0);
+    occupancies.fill(0);
+    side = WHITE;
+}
+
+bool Board::loadFEN(const std::string& fen) {
+    bitboards.fill(0);
+    occupancies.fill(0);
+    side = WHITE;
+
+    std::istringstream iss(fen);
+    std::string boardPart, sidePart, castling, ep;
+    if (!(iss >> boardPart >> sidePart >> castling >> ep))
+        return false;
+
+    int sq = 56; // start from A8
+    for (char c : boardPart) {
+        if (c == '/') {
+            sq -= 16; // move to next rank
+        } else if (c >= '1' && c <= '8') {
+            sq += c - '0';
+        } else {
+            int p = char_to_piece(c);
+            if (p < 0) return false;
+            bitboards[p] |= 1ULL << sq;
+            sq++;
+        }
+    }
+
+    side = (sidePart == "w" ? WHITE : BLACK);
+
+    occupancies[WHITE] = bitboards[WP] | bitboards[WN] | bitboards[WB] |
+                         bitboards[WR] | bitboards[WQ] | bitboards[WK];
+    occupancies[BLACK] = bitboards[BP] | bitboards[BN] | bitboards[BB] |
+                         bitboards[BR] | bitboards[BQ] | bitboards[BK];
+    occupancies[2] = occupancies[WHITE] | occupancies[BLACK];
+
+    return true;
+}
+
+std::string Board::getFEN() const {
+    // Only piece placement and side to move, for simplicity
+    std::string s;
+    for (int rank = 7; rank >= 0; --rank) {
+        int empty = 0;
+        for (int file = 0; file < 8; ++file) {
+            int sq = rank * 8 + file;
+            bool found = false;
+            for (int p = 0; p < PIECE_NB; ++p) {
+                if (bitboards[p] & (1ULL << sq)) {
+                    if (empty) { s += char('0' + empty); empty = 0; }
+                    const char* pieces = "PNBRQKpnbrqk";
+                    s += pieces[p];
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) empty++;
+        }
+        if (empty) s += char('0' + empty);
+        if (rank > 0) s += '/';
+    }
+    s += side == WHITE ? " w" : " b";
+    s += " - - 0 1"; // stub
+    return s;
+}
+
+// ================= Magic bitboards =====================
+
+static std::array<Magic, 64> rookMagics;
+static std::array<Magic, 64> bishopMagics;
+
+static uint64_t random_uint64() {
+    static uint64_t x = 88172645463325252ULL;
+    x ^= x << 7;  x ^= x >> 9;
+    return x;
+}
+
+static int popcount(uint64_t b) {
+    return __builtin_popcountll(b);
+}
+
+static uint64_t rook_mask(int sq) {
+    int r = sq / 8, f = sq % 8;
+    uint64_t mask = 0;
+    for (int r1 = r + 1; r1 <= 6; ++r1) mask |= 1ULL << (r1 * 8 + f);
+    for (int r1 = r - 1; r1 >= 1; --r1) mask |= 1ULL << (r1 * 8 + f);
+    for (int f1 = f + 1; f1 <= 6; ++f1) mask |= 1ULL << (r * 8 + f1);
+    for (int f1 = f - 1; f1 >= 1; --f1) mask |= 1ULL << (r * 8 + f1);
+    return mask;
+}
+
+static uint64_t bishop_mask(int sq) {
+    int r = sq / 8, f = sq % 8;
+    uint64_t mask = 0;
+    for (int r1=r+1,f1=f+1; r1<=6 && f1<=6; ++r1,++f1) mask |= 1ULL << (r1*8+f1);
+    for (int r1=r+1,f1=f-1; r1<=6 && f1>=1; ++r1,--f1) mask |= 1ULL << (r1*8+f1);
+    for (int r1=r-1,f1=f+1; r1>=1 && f1<=6; --r1,++f1) mask |= 1ULL << (r1*8+f1);
+    for (int r1=r-1,f1=f-1; r1>=1 && f1>=1; --r1,--f1) mask |= 1ULL << (r1*8+f1);
+    return mask;
+}
+
+static uint64_t sliding_attack(bool bishop, int sq, uint64_t occ) {
+    uint64_t attacks = 0;
+    int r = sq / 8, f = sq % 8;
+
+    static const int rookDirs[4][2] = {{1,0},{-1,0},{0,1},{0,-1}};
+    static const int bishopDirs[4][2] = {{1,1},{1,-1},{-1,1},{-1,-1}};
+
+    const int (*dirs)[2] = bishop ? bishopDirs : rookDirs;
+    int count = 4;
+    for (int i=0;i<count;++i) {
+        int dr = dirs[i][0];
+        int df = dirs[i][1];
+        int r1=r+dr, f1=f+df;
+        while (r1>=0 && r1<8 && f1>=0 && f1<8) {
+            int sq1 = r1*8+f1;
+            attacks |= 1ULL<<sq1;
+            if (occ & (1ULL<<sq1)) break;
+            r1+=dr; f1+=df;
+        }
+    }
+    return attacks;
+}
+
+static void init_magic_array(bool bishop, std::array<Magic,64>& magics) {
+    for (int sq=0; sq<64; ++sq) {
+        Magic m{};
+        m.mask = bishop ? bishop_mask(sq) : rook_mask(sq);
+        int bits = popcount(m.mask);
+        m.shift = 64 - bits;
+        size_t size = 1ULL << bits;
+        m.attacks.assign(size, 0);
+
+        std::vector<uint64_t> occupancies(size);
+        std::vector<uint64_t> references(size);
+
+        uint64_t b=0;
+        for (size_t i=0;i<size;++i) {
+            occupancies[i]=b;
+            references[i]=sliding_attack(bishop,sq,b);
+            b=(b-m.mask)&m.mask;
+        }
+
+        bool found=false;
+        for(int k=0;k<100000 && !found;++k){
+            uint64_t magic=random_uint64()&random_uint64()&random_uint64();
+
+            if(popcount((magic*m.mask)>>56)<6) continue;
+            std::vector<uint64_t> used(size, 0xFFFFFFFFFFFFFFFFULL);
+            bool fail=false;
+            for(size_t i=0;i<size && !fail;++i){
+                uint64_t idx=(occupancies[i]*magic)>>m.shift;
+                if(used[idx]==0xFFFFFFFFFFFFFFFFULL) used[idx]=references[i];
+                else if(used[idx]!=references[i]) fail=true;
+            }
+            if(!fail){
+                m.magic=magic;
+                for(size_t i=0;i<size;++i){
+                    uint64_t idx=(occupancies[i]*magic)>>m.shift;
+                    m.attacks[idx]=references[i];
+                }
+                found=true;
+            }
+        }
+        if(!found){
+            // fallback: simple attacks without magic
+            for(size_t i=0;i<size;++i){
+                m.attacks[i]=references[i];
+            }
+        }
+        magics[sq]=m;
+    }
+}
+
+void init_magics() {
+    init_magic_array(false, rookMagics);
+    init_magic_array(true, bishopMagics);
+}
+
+uint64_t bishop_attacks(int sq, uint64_t occ) {
+    const Magic& m = bishopMagics[sq];
+    uint64_t occMask = occ & m.mask;
+    uint64_t idx = (occMask * m.magic) >> m.shift;
+    if(idx < m.attacks.size()) return m.attacks[idx];
+    return 0ULL;
+}
+
+uint64_t rook_attacks(int sq, uint64_t occ) {
+    const Magic& m = rookMagics[sq];
+    uint64_t occMask = occ & m.mask;
+    uint64_t idx = (occMask * m.magic) >> m.shift;
+    if(idx < m.attacks.size()) return m.attacks[idx];
+    return 0ULL;
+}
+
+} // namespace ct2

--- a/src/board.h
+++ b/src/board.h
@@ -1,0 +1,49 @@
+#ifndef CT2_BOARD_H
+#define CT2_BOARD_H
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace ct2 {
+
+enum Piece {
+    WP, WN, WB, WR, WQ, WK,
+    BP, BN, BB, BR, BQ, BK,
+    PIECE_NB
+};
+
+enum Color { WHITE, BLACK, COLOR_NB };
+
+struct Magic {
+    uint64_t mask;
+    uint64_t magic;
+    int shift;
+    std::vector<uint64_t> attacks;
+};
+
+class Board {
+public:
+    Board();
+    bool loadFEN(const std::string& fen);
+    std::string getFEN() const;
+
+    uint64_t pieceBB(Piece p) const { return bitboards[p]; }
+    uint64_t occupancyBB(Color c) const { return occupancies[c]; }
+    uint64_t occupancyBB() const { return occupancies[2]; }
+
+private:
+    std::array<uint64_t, PIECE_NB> bitboards{};
+    std::array<uint64_t, 3> occupancies{}; // white, black, both
+    Color side;
+};
+
+// Magic bitboard related
+void init_magics();
+uint64_t bishop_attacks(int sq, uint64_t occ);
+uint64_t rook_attacks(int sq, uint64_t occ);
+
+} // namespace ct2
+
+#endif // CT2_BOARD_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,9 @@
+#include "board.h"
+#include "uci.h"
+
+int main() {
+    ct2::init_magics();
+    ct2::Board board;
+    ct2::uci_loop(board);
+    return 0;
+}

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -1,0 +1,44 @@
+#include "uci.h"
+
+#include <iostream>
+#include <sstream>
+
+namespace ct2 {
+
+void uci_loop(Board& board) {
+    std::string token;
+    std::cout << "id name ct2" << std::endl;
+    std::cout << "id author codex" << std::endl;
+    std::cout << "uciok" << std::endl;
+
+    while (std::getline(std::cin, token)) {
+        if (token == "isready") {
+            std::cout << "readyok" << std::endl;
+        } else if (token == "quit") {
+            break;
+        } else if (token.rfind("position", 0) == 0) {
+            std::istringstream ss(token);
+            std::string word;
+            ss >> word; // position
+            if (ss >> word) {
+                if (word == "startpos") {
+                    board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
+                    if (ss >> word && word == "moves") {
+                        // ignore moves for now
+                    }
+                } else if (word == "fen") {
+                    std::string fen;
+                    std::getline(ss, fen);
+                    if (!fen.empty() && fen[0] == ' ') fen = fen.substr(1);
+                    board.loadFEN(fen);
+                }
+            }
+        } else if (token == "ucinewgame") {
+            // nothing
+        } else if (token.rfind("go", 0) == 0) {
+            std::cout << "bestmove 0000" << std::endl;
+        }
+    }
+}
+
+} // namespace ct2

--- a/src/uci.h
+++ b/src/uci.h
@@ -1,0 +1,12 @@
+#ifndef CT2_UCI_H
+#define CT2_UCI_H
+
+#include "board.h"
+
+namespace ct2 {
+
+void uci_loop(Board& board);
+
+} // namespace ct2
+
+#endif // CT2_UCI_H

--- a/tests/board_tests.cpp
+++ b/tests/board_tests.cpp
@@ -1,0 +1,23 @@
+#include "board.h"
+#include <gtest/gtest.h>
+
+using namespace ct2;
+
+TEST(BoardTest, LoadFEN) {
+    Board b;
+    ASSERT_TRUE(b.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"));
+    EXPECT_EQ(b.occupancyBB(WHITE), 0xFFFFULL);
+    EXPECT_TRUE(b.occupancyBB() != 0);
+}
+
+TEST(MagicTest, RookAttacks) {
+    init_magics();
+    uint64_t occ = 0;
+    uint64_t attacks = rook_attacks(27, occ); // d4
+    EXPECT_EQ(__builtin_popcountll(attacks), 14);
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add CMake build
- implement board representation with magic bitboards
- add a simple UCI loop
- provide minimal tests using GoogleTest

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/ct2_tests`

------
https://chatgpt.com/codex/tasks/task_b_6888a6e1f478832d82c3cde2d3a14c4f