### PR TITLE
Fix portable popcount

### DIFF
--- a/src/bitops.h
+++ b/src/bitops.h
@@ -1,0 +1,49 @@
+#ifndef CT2_BITOPS_H
+#define CT2_BITOPS_H
+
+#include <cstdint>
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
+namespace ct2 {
+
+// Portable population count for 64-bit integers
+inline int popcount64(uint64_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_popcountll(x);
+#elif defined(_MSC_VER)
+    return static_cast<int>(__popcnt64(x));
+#else
+    int count = 0;
+    while (x) {
+        x &= x - 1;
+        ++count;
+    }
+    return count;
+#endif
+}
+
+// Portable count trailing zeros for 64-bit integers
+inline int ctz64(uint64_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_ctzll(x);
+#elif defined(_MSC_VER)
+    unsigned long index;
+    _BitScanForward64(&index, x);
+    return static_cast<int>(index);
+#else
+    if (x == 0) return 64;
+    int n = 0;
+    while ((x & 1) == 0) {
+        x >>= 1;
+        ++n;
+    }
+    return n;
+#endif
+}
+
+} // namespace ct2
+
+#endif // CT2_BITOPS_H
+

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1,4 +1,5 @@
 #include "board.h"
+#include "bitops.h"
 
 #include <cassert>
 #include <cstring>
@@ -110,7 +111,7 @@ static std::array<uint64_t, 64> knightAttacks;
 static std::array<uint64_t, 64> kingAttacks;
 
 static int pop_lsb(uint64_t& b) {
-    int sq = __builtin_ctzll(b);
+    int sq = ctz64(b);
     b &= b - 1;
     return sq;
 }
@@ -249,18 +250,6 @@ static uint64_t random_uint64() {
 
 
 
-unsigned int popcount64(unsigned long long x) {
-    unsigned int count = 0;
-    while (x) {
-        count += x & 1;
-        x >>= 1;
-    }
-    return count;
-}
-
-static int popcount(uint64_t b) {
-    return popcount64(b);
-}
 
 static uint64_t knight_mask(int sq) {
     int r = sq / 8, f = sq % 8;
@@ -333,7 +322,7 @@ static void init_magic_array(bool bishop, std::array<Magic,64>& magics) {
     for (int sq=0; sq<64; ++sq) {
         Magic m{};
         m.mask = bishop ? bishop_mask(sq) : rook_mask(sq);
-        int bits = popcount(m.mask);
+        int bits = popcount64(m.mask);
         m.shift = 64 - bits;
         size_t size = 1ULL << bits;
         m.attacks.assign(size, 0);
@@ -352,7 +341,7 @@ static void init_magic_array(bool bishop, std::array<Magic,64>& magics) {
         for(int k=0;k<100000 && !found;++k){
             uint64_t magic=random_uint64()&random_uint64()&random_uint64();
 
-            if(popcount((magic*m.mask)>>56)<6) continue;
+            if(popcount64((magic*m.mask)>>56) < 6) continue;
             std::vector<uint64_t> used(size, 0xFFFFFFFFFFFFFFFFULL);
             bool fail=false;
             for(size_t i=0;i<size && !fail;++i){

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -1,4 +1,5 @@
 #include "uci.h"
+#include "bitops.h"
 #include <algorithm>
 #include <cctype>
 
@@ -37,7 +38,7 @@ static int evaluate(const Board& b) {
     static const int val[PIECE_NB] = {100,320,330,500,900,0,-100,-320,-330,-500,-900,0};
     int score = 0;
     for(int p=WP; p<PIECE_NB; ++p) {
-        score += __builtin_popcountll(b.pieceBB((Piece)p)) * val[p];
+        score += popcount64(b.pieceBB((Piece)p)) * val[p];
     }
     return (b.side_to_move()==WHITE?1:-1)*score;
 }

--- a/tests/board_tests.cpp
+++ b/tests/board_tests.cpp
@@ -1,4 +1,5 @@
 #include "board.h"
+#include "bitops.h"
 #include <gtest/gtest.h>
 
 using namespace ct2;
@@ -14,7 +15,7 @@ TEST(MagicTest, RookAttacks) {
     init_magics();
     uint64_t occ = 0;
     uint64_t attacks = rook_attacks(27, occ); // d4
-    EXPECT_EQ(__builtin_popcountll(attacks), 14);
+    EXPECT_EQ(popcount64(attacks), 14);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary
- add new header `bitops.h` with portable `popcount64` and `ctz64`
- use these helpers in `board.cpp`, `uci.cpp` and tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cmake --build build --target ct2_tests`
- `./build/ct2_tests`

------
https://chatgpt.com/codex/tasks/task_b_6888c87ee628832d9503f8996cfc2966