### PR TITLE
Add castling and en passant

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -34,6 +34,9 @@ public:
         int to;
         Piece piece;
         Piece capture;
+        Piece promotion;
+        bool is_ep;
+        bool is_castling;
     };
 
     std::vector<Move> generate_moves() const;
@@ -48,6 +51,8 @@ private:
     std::array<uint64_t, PIECE_NB> bitboards{};
     std::array<uint64_t, 3> occupancies{}; // white, black, both
     Color side;
+    uint8_t castling; // KQkq = 1|2|4|8
+    int ep_square;    // -1 if none
 
     void update_occupancies();
 };


### PR DESCRIPTION
## Summary
- extend `Board::Move` to encode promotions, en-passant and castling
- keep castling rights and en-passant square in `Board`
- parse/print these fields in FEN
- generate pawn double pushes, promotions, en-passant and castling moves
- apply special rules in `make_move`
- update UCI helpers for promotion moves

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/ct2_tests`


------
https://chatgpt.com/codex/tasks/task_b_6888ca96943c832dbd5364b88f027b84