### PR TITLE
Add Stockfish test and fix illegal moves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,5 +27,13 @@ FetchContent_MakeAvailable(googletest)
 file(GLOB TEST_SOURCES tests/*.cpp)
 add_executable(ct2_tests ${TEST_SOURCES})
 target_link_libraries(ct2_tests PRIVATE ct2lib gtest_main)
+add_dependencies(ct2_tests ct2)
 
 add_test(NAME ct2_tests COMMAND ct2_tests)
+
+# Python integration test using Stockfish
+add_test(
+  NAME full_game_test
+  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/full_game_test.py
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/src/board.h
+++ b/src/board.h
@@ -40,6 +40,9 @@ public:
     };
 
     std::vector<Move> generate_moves() const;
+    std::vector<Move> generate_legal_moves() const;
+    bool square_attacked(int sq, Color by) const;
+    bool in_check(Color c) const;
     bool make_move(const Move& m);
 
     uint64_t pieceBB(Piece p) const { return bitboards[p]; }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -97,7 +97,7 @@ static int evaluate(const Board& b) {
 
 static int negamax(Board& b, int depth, int alpha, int beta) {
     if (depth == 0) return evaluate(b);
-    auto moves = b.generate_moves();
+    auto moves = b.generate_legal_moves();
     if (moves.empty()) return -100000 + depth; // checkmate or stalemate
     int best = -1000000;
     for (const auto& mv : moves) {
@@ -112,7 +112,7 @@ static int negamax(Board& b, int depth, int alpha, int beta) {
 }
 
 static Board::Move search_best(Board& b) {
-    auto moves = b.generate_moves();
+    auto moves = b.generate_legal_moves();
     if(moves.empty()) return Board::Move{0,0,WP,PIECE_NB,PIECE_NB,false,false};
     Board::Move best = moves[0];
     int bestScore = -1000000;

--- a/tests/full_game_test.py
+++ b/tests/full_game_test.py
@@ -1,0 +1,26 @@
+import os
+import chess
+import chess.engine
+
+ENGINE_PATH = os.path.join(os.path.dirname(__file__), '..', 'build', 'ct2')
+STOCKFISH = '/usr/games/stockfish'
+
+MAX_PLIES = 20  # 10 moves each side
+
+def main():
+    board = chess.Board()
+    with chess.engine.SimpleEngine.popen_uci(ENGINE_PATH) as eng, \
+         chess.engine.SimpleEngine.popen_uci(STOCKFISH) as sf:
+        for _ in range(MAX_PLIES):
+            res = eng.play(board, chess.engine.Limit(depth=1))
+            if not board.is_legal(res.move):
+                raise AssertionError(f'Engine produced illegal move: {res.move}')
+            board.push(res.move)
+
+            res = sf.play(board, chess.engine.Limit(depth=1))
+            if not board.is_legal(res.move):
+                raise AssertionError(f'Stockfish produced illegal move: {res.move}')
+            board.push(res.move)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a full-game integration test using Stockfish
- link the new test in CMake
- filter generated moves so only legal moves are returned
- add `square_attacked` and `in_check` helpers
- fix pawn capture masks so off-board moves are not generated

## Testing
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_6889fd6b4a5c832d8b44d08ea21fd203