### PR TITLE
Fix illegal pawn capture and update test path

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -273,7 +273,9 @@ std::vector<Board::Move> Board::generate_moves() const {
             int from = to + 16;
             moves.push_back({from,to,BP,PIECE_NB,PIECE_NB,false,false});
         }
-        uint64_t captL = ((pawns & ~0x0101010101010101ULL) >> 7) & opp;
+        // Captures to the pawn's left (towards file decrease).
+        // Pawns on the h-file cannot capture left so mask them out.
+        uint64_t captL = ((pawns & ~0x8080808080808080ULL) >> 7) & opp;
         t = captL;
         while (t) {
             int to = pop_lsb(t);
@@ -284,7 +286,9 @@ std::vector<Board::Move> Board::generate_moves() const {
             else
                 moves.push_back({from,to,BP,cap,PIECE_NB,false,false});
         }
-        uint64_t captR = ((pawns & ~0x8080808080808080ULL) >> 9) & opp;
+        // Captures to the pawn's right (towards file increase).
+        // Pawns on the a-file cannot capture right so mask them out.
+        uint64_t captR = ((pawns & ~0x0101010101010101ULL) >> 9) & opp;
         t = captR;
         while (t) {
             int to = pop_lsb(t);
@@ -297,14 +301,16 @@ std::vector<Board::Move> Board::generate_moves() const {
         }
         if (ep_square != -1) {
             uint64_t epBB = 1ULL << ep_square;
-            uint64_t epL = ((pawns & ~0x0101010101010101ULL) >> 7) & epBB;
+            // En passant capture to the left
+            uint64_t epL = ((pawns & ~0x8080808080808080ULL) >> 7) & epBB;
             t = epL;
             while (t) {
                 int to = pop_lsb(t);
                 int from = to + 7;
                 moves.push_back({from,to,BP,WP,PIECE_NB,true,false});
             }
-            uint64_t epR = ((pawns & ~0x8080808080808080ULL) >> 9) & epBB;
+            // En passant capture to the right
+            uint64_t epR = ((pawns & ~0x0101010101010101ULL) >> 9) & epBB;
             t = epR;
             while (t) {
                 int to = pop_lsb(t);

--- a/tests/random_position_tests.cpp
+++ b/tests/random_position_tests.cpp
@@ -15,7 +15,7 @@ TEST(MoveGeneration, StartPositionMoves) {
 
 TEST(MoveGeneration, RandomPositions) {
     init_tables();
-    std::ifstream in("../tests/random_positions.txt");
+    std::ifstream in("tests/random_positions.txt");
     ASSERT_TRUE(in.is_open());
     std::string boardPart, side, castling, ep;
     int halfmove, fullmove;


### PR DESCRIPTION
## Summary
- fix black pawn capture masks to stop illegal diagonal wraparound
- update random position test to load the input file correctly

## Testing
- `cmake --build build`
- `./build/ct2_tests`

------
https://chatgpt.com/codex/tasks/task_b_688c85349868832d84bdd0538b368258