### PR TITLE
Improve chess engine with pruning, opening book, and evaluation output

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -4,6 +4,8 @@
 #include <cctype>
 #include <array>
 #include <vector>
+#include <unordered_map>
+#include <random>
 
 #include <iostream>
 #include <sstream>
@@ -11,6 +13,20 @@
 namespace ct2 {
 
 static const int VAL_PIECE[6] = {100,320,330,500,900,0};
+
+struct TTEntry {
+    int depth;
+    int score;
+};
+
+static std::unordered_map<std::string, TTEntry> TT;
+static uint64_t nodes = 0;
+
+static std::unordered_map<std::string, std::vector<std::string>> openingBook = {
+    {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+     {"e2e4", "d2d4", "c2c4", "g1f3"}}
+};
+static std::mt19937 rng(2024);
 
 static int quiescence(Board& b, int alpha, int beta);
 
@@ -81,6 +97,16 @@ static std::string move_to_str(const Board::Move& m) {
     return s;
 }
 
+static bool get_book_move(const Board& b, Board::Move& out) {
+    auto it = openingBook.find(b.getFEN());
+    if (it == openingBook.end()) return false;
+    const auto& moves = it->second;
+    if (moves.empty()) return false;
+    std::uniform_int_distribution<size_t> dist(0, moves.size() - 1);
+    out = parse_move(moves[dist(rng)], b);
+    return true;
+}
+
 static int piece_square(Piece p, int sq) {
     int f = sq % 8;
     int r = sq / 8;
@@ -124,17 +150,36 @@ static int move_order_score(const Board::Move& mv) {
     return score;
 }
 
+static bool is_quiet(const Board::Move& mv) {
+    return mv.capture == PIECE_NB && mv.promotion == PIECE_NB;
+}
+
+struct SearchResult {
+    Board::Move best;
+    int score;
+};
+
 static int negamax(Board& b, int depth, int alpha, int beta) {
+    nodes++;
     if (depth == 0) {
         return quiescence(b, alpha, beta);
     }
+
+    std::string key = b.getFEN();
+    auto ttIt = TT.find(key);
+    if (ttIt != TT.end() && ttIt->second.depth >= depth)
+        return ttIt->second.score;
+
     auto moves = b.generate_legal_moves();
     if (moves.empty()) return -100000 + depth; // checkmate or stalemate
     std::sort(moves.begin(), moves.end(), [](const Board::Move& a, const Board::Move& b) {
         return move_order_score(a) > move_order_score(b);
     });
+    int eval = 0;
+    if (depth == 1) eval = evaluate(b);
     int best = -1000000;
     for (const auto& mv : moves) {
+        if (depth == 1 && is_quiet(mv) && eval + 200 <= alpha) continue; // futility pruning
         Board copy = b;
         copy.make_move(mv);
         int score = -negamax(copy, depth - 1, -beta, -alpha);
@@ -142,10 +187,12 @@ static int negamax(Board& b, int depth, int alpha, int beta) {
         if (best > alpha) alpha = best;
         if (alpha >= beta) break;
     }
+    TT[key] = {depth, best};
     return best;
 }
 
 static int quiescence(Board& b, int alpha, int beta) {
+    nodes++;
     int stand_pat = evaluate(b);
     if (stand_pat >= beta) return beta;
     if (alpha < stand_pat) alpha = stand_pat;
@@ -164,9 +211,17 @@ static int quiescence(Board& b, int alpha, int beta) {
     return alpha;
 }
 
-static Board::Move search_best(Board& b) {
+static SearchResult search_best(Board& b) {
+    Board::Move bookMove;
+    if (get_book_move(b, bookMove)) {
+        Board copy = b;
+        copy.make_move(bookMove);
+        int sc = evaluate(copy);
+        return {bookMove, sc};
+    }
     auto moves = b.generate_legal_moves();
-    if(moves.empty()) return Board::Move{0,0,WP,PIECE_NB,PIECE_NB,false,false};
+    if(moves.empty())
+        return {Board::Move{0,0,WP,PIECE_NB,PIECE_NB,false,false}, evaluate(b)};
     std::sort(moves.begin(), moves.end(), [](const Board::Move& a, const Board::Move& b) {
         return move_order_score(a) > move_order_score(b);
     });
@@ -178,7 +233,7 @@ static Board::Move search_best(Board& b) {
         int sc = -negamax(copy, 4, -1000000, 1000000);
         if(sc > bestScore) { bestScore = sc; best = mv; }
     }
-    return best;
+    return {best, bestScore};
 }
 
 void uci_loop(Board& board) {
@@ -215,8 +270,12 @@ void uci_loop(Board& board) {
         } else if (token == "ucinewgame") {
             // nothing
         } else if (token.rfind("go", 0) == 0) {
-            auto best = search_best(board);
-            std::cout << "bestmove " << move_to_str(best) << std::endl;
+            nodes = 0;
+            auto result = search_best(board);
+            std::cout << "info score cp " << result.score
+                      << " depth 4 nodes " << nodes
+                      << " pv " << move_to_str(result.best) << std::endl;
+            std::cout << "bestmove " << move_to_str(result.best) << std::endl;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add basic transposition table, futility pruning, and node counting to speed search.
- Integrate a small hard-coded opening book.
- Return evaluation scores and principal variation via UCI `info` output.

## Testing
- `cmake --build build`
- `ctest` *(fails: missing `tests/random_positions.txt` and Python `chess` module)*

------
https://chatgpt.com/codex/tasks/task_b_6891ba3ce008832d9228f5b3181de7c3